### PR TITLE
backend wyrm leaderboard

### DIFF
--- a/contracts/WyrmAutoBattler.vy
+++ b/contracts/WyrmAutoBattler.vy
@@ -23,14 +23,14 @@ def battle(_player1 : address, _id1 : uint256, _player2 : address, _id2 : uint25
     defense1 : uint256 = 0
     crit1 : uint256 = 0
     
-    hp1, attack1, defense1, crit1 = self.getStats(_id1)
+    hp1, attack1, defense1, crit1 = self._getStats(_id1)
 
     hp2 : uint256 = 0
     attack2 : uint256 = 0
     defense2 : uint256 = 0
     crit2 : uint256 = 0
     
-    hp2, attack2, defense2, crit2 = self.getStats(_id2)
+    hp2, attack2, defense2, crit2 = self._getStats(_id2)
 
     for i in range(1, 100):
         round_damage1 : uint256 = 0
@@ -76,8 +76,8 @@ def playRound(hp1 : uint256, attack1 : uint256, defense1 : uint256, crit1 : uint
 
     return damage1, damage2
 
-@external
-def getStats(_id : uint256) -> (uint256, uint256, uint256, uint256):
+@internal
+def _getStats(_id : uint256) -> (uint256, uint256, uint256, uint256):
     stats : uint64 = self.token_contract.tokenURI(_id)
 
     hp : uint256 = convert(stats/10000000, uint256)
@@ -86,6 +86,25 @@ def getStats(_id : uint256) -> (uint256, uint256, uint256, uint256):
     crit : uint256 = convert((stats & 100), uint256)
 
     return hp, attack, defense, crit
+
+@external
+def getStats(_id : uint256) -> (uint256, uint256, uint256, uint256):
+    return self._getStats(_id)
+
+@external
+def getTotalStats(_id: uint256) -> uint256:
+    # Call the _getStats method
+    hp: uint256 = 0
+    attack: uint256 = 0
+    defense: uint256 = 0
+    crit: uint256 = 0
+    
+    hp, attack, defense, crit = self._getStats(_id)
+    
+    # Calculate the total stats
+    total_stats: uint256 = hp + attack + defense + crit
+    
+    return total_stats
 
 @internal
 def _rand() -> uint256:

--- a/contracts/WyrmAutoBattler.vy
+++ b/contracts/WyrmAutoBattler.vy
@@ -72,7 +72,7 @@ def playRound(hp1 : uint256, attack1 : uint256, defense1 : uint256, crit1 : uint
 
     return damage1, damage2
 
-@internal
+@external
 def getStats(_id : uint256) -> (uint256, uint256, uint256, uint256):
     stats : uint64 = self.token_contract.tokenURI(_id)
 

--- a/contracts/wyrm-leaderboard.vy
+++ b/contracts/wyrm-leaderboard.vy
@@ -11,6 +11,7 @@ struct StackItem:
     low: int128
     high: int128
 
+#sorts accounts by total stats
 @external
 def quicksort_accounts(wyrm_auto_battler: address, accounts: address[10], ids: uint256[10]) -> address[10]:
     n: int128 = 10  # The length of the accounts array

--- a/contracts/wyrm-leaderboard.vy
+++ b/contracts/wyrm-leaderboard.vy
@@ -1,22 +1,25 @@
 # @version ^0.3.10
 
-# State variable to hold the ID
-id: uint256
-
 # Interface definition for WyrmAutoBattler
 interface WyrmAutoBattler:
     def getStats(_id: uint256) -> (uint256, uint256, uint256, uint256): view
+    def getTotalStats(tokenId: uint256) -> uint256: view
 
-# Sort wyrms
+# State variable to hold the ID
+id: uint256
+
+# Sort wyrms (placeholder)
 @external
 def sortWorms():
-    # Placeholder function as there is no actual implementation provided
     pass
 
+# Function to get the total stats from an external contract
 @external
-def getTotal(id: uint256) -> uint256:
-    # Declare and initialize variables
-    total: uint256 = 0
-
-    total = WyrmAutoBattler.getTotalStats(id)
+def getTotal(wyrm_auto_battler: address, id: uint256) -> uint256:
+    # Create an instance of the WyrmAutoBattler interface at the given address
+    battler: WyrmAutoBattler = WyrmAutoBattler(wyrm_auto_battler)
     
+    # Call getTotalStats on the instance
+    total: uint256 = battler.getTotalStats(id)
+    
+    return total

--- a/contracts/wyrm-leaderboard.vy
+++ b/contracts/wyrm-leaderboard.vy
@@ -1,9 +1,5 @@
 # @version ^0.3.10
 
-from vyper.interfaces import ERC20
-
-implements: ERC20
-
 # State variable to hold the ID
 id: uint256
 
@@ -17,17 +13,10 @@ def sortWorms():
     # Placeholder function as there is no actual implementation provided
     pass
 
-# Helper method to get the total stats of a wyrm
-@internal
+@external
 def getTotal(id: uint256) -> uint256:
-    # Retrieve stats using the interface method
-    attack: uint256
-    defense: uint256
-    speed: uint256
-    health: uint256
-    attack, defense, speed, health = WyrmAutoBattler.getStats(id)
+    # Declare and initialize variables
+    total: uint256 = 0
+
+    total = WyrmAutoBattler.getTotalStats(id)
     
-    # Calculate the total stats
-    total: uint256 = attack + defense + speed + health
-    
-    return total

--- a/contracts/wyrm-leaderboard.vy
+++ b/contracts/wyrm-leaderboard.vy
@@ -7,6 +7,71 @@ interface WyrmAutoBattler:
 
 # State variable to hold the ID
 id: uint256
+struct StackItem:
+    low: int128
+    high: int128
+
+@external
+def quicksort_accounts(wyrm_auto_battler: address, accounts: address[10], ids: uint256[10]) -> address[10]:
+    n: int128 = 10  # The length of the accounts array
+    
+    if n <= 1:
+        return accounts
+
+    # Initialize stack for iterative QuickSort
+    stack: StackItem[10] = empty(StackItem[10])
+    top: int128 = 0
+
+    # Push initial values to stack
+    stack[top] = StackItem({low: 0, high: n - 1})
+
+    for _ in range(100):  # Arbitrary large number to avoid while loop
+        if top < 0:
+            break
+
+        # Pop from stack
+        high: int128 = stack[top].high
+        low: int128 = stack[top].low
+        top -= 1
+
+        # Partition the array
+        pivot_index: int128 = self.partition(wyrm_auto_battler, accounts, ids, low, high)
+
+        # Push sub-arrays to stack if they are within range
+        if pivot_index - 1 > low:
+            top += 1
+            stack[top] = StackItem({low: low, high: pivot_index - 1})
+
+        if pivot_index + 1 < high:
+            top += 1
+            stack[top] = StackItem({low: pivot_index + 1, high: high})
+
+    return accounts
+
+@internal
+def partition(wyrm_auto_battler: address, accounts: address[10], ids: uint256[10], low: int128, high: int128) -> int128:
+    battler: WyrmAutoBattler = WyrmAutoBattler(wyrm_auto_battler)
+    pivot: uint256 = battler.getTotalStats(ids[high])
+    i: int128 = low - 1
+
+    for j in range(10):  # Using a fixed-size loop to cover the maximum possible range
+        if j >= low and j < high:  # Ensuring we only operate within the valid range
+            if battler.getTotalStats(ids[j]) < pivot:
+                i += 1
+                self.swap(accounts, ids, i, j)
+
+    self.swap(accounts, ids, i + 1, high)
+    return i + 1
+
+@internal
+def swap(accounts: address[10], ids: uint256[10], i: int128, j: int128):
+    temp_account: address = accounts[i]
+    temp_id: uint256 = ids[i]
+    accounts[i] = accounts[j]
+    ids[i] = ids[j]
+    accounts[j] = temp_account
+    ids[j] = temp_id
+
 
 # Sort wyrms (placeholder)
 @external

--- a/contracts/wyrm-leaderboard.vy
+++ b/contracts/wyrm-leaderboard.vy
@@ -1,0 +1,33 @@
+# @version ^0.3.10
+
+from vyper.interfaces import ERC20
+
+implements: ERC20
+
+# State variable to hold the ID
+id: uint256
+
+# Interface definition for WyrmAutoBattler
+interface WyrmAutoBattler:
+    def getStats(_id: uint256) -> (uint256, uint256, uint256, uint256): view
+
+# Sort wyrms
+@external
+def sortWorms():
+    # Placeholder function as there is no actual implementation provided
+    pass
+
+# Helper method to get the total stats of a wyrm
+@internal
+def getTotal(id: uint256) -> uint256:
+    # Retrieve stats using the interface method
+    attack: uint256
+    defense: uint256
+    speed: uint256
+    health: uint256
+    attack, defense, speed, health = WyrmAutoBattler.getStats(id)
+    
+    # Calculate the total stats
+    total: uint256 = attack + defense + speed + health
+    
+    return total

--- a/tests/wyrm-leaderboard-tester.py
+++ b/tests/wyrm-leaderboard-tester.py
@@ -1,0 +1,31 @@
+from ape import accounts, project
+
+def test_sort_worms(accounts):
+    # Deploy the contract
+    owner = accounts[0]  # Assuming the first account is the owner
+    wyrm_sorting_contract = project.WyrmSorting.deploy(sender=owner)
+    
+    # Mock WyrmAutoBattler contract
+    class MockWyrmAutoBattler:
+        def getStats(self, _id):
+            # Return mock stats: attack, defense, speed, health
+            return (100 + _id, 200 + _id, 300 + _id, 400 + _id)
+    
+    # Assign mock WyrmAutoBattler to the contract
+    wyrm_sorting_contract.WyrmAutoBattler = MockWyrmAutoBattler()
+    
+    # Test getTotal function indirectly by calling a public function that uses it
+    def test_get_total(id):
+        # Call the internal getTotal function through the public sortWorms
+        total = wyrm_sorting_contract.getTotal(id)
+        expected_total = (100 + id) + (200 + id) + (300 + id) + (400 + id)
+        assert total == expected_total, f"Total {total} does not match expected {expected_total}"
+    
+    # Test for a few ids
+    for wyrm_id in range(1, 4):
+        test_get_total(wyrm_id)
+    
+    print("Test passed, getTotal method works correctly.")
+
+# Call the test function
+test_sort_worms(accounts)

--- a/tests/wyrm-leaderboard-tester.py
+++ b/tests/wyrm-leaderboard-tester.py
@@ -1,31 +1,20 @@
 from ape import accounts, project
 
-def test_sort_worms(accounts):
-    # Deploy the contract
-    owner = accounts[0]  # Assuming the first account is the owner
+def test_get_total_stats(accounts):
+    # Deploy the WyrmSorting contract
+    owner = accounts[0]
     wyrm_sorting_contract = project.WyrmSorting.deploy(sender=owner)
     
-    # Mock WyrmAutoBattler contract
-    class MockWyrmAutoBattler:
-        def getStats(self, _id):
-            # Return mock stats: attack, defense, speed, health
-            return (100 + _id, 200 + _id, 300 + _id, 400 + _id)
+    # Deploy the MockWyrmAutoBattler contract
+    mock_wyrm_auto_battler = project.MockWyrmAutoBattler.deploy(sender=owner)
     
-    # Assign mock WyrmAutoBattler to the contract
-    wyrm_sorting_contract.WyrmAutoBattler = MockWyrmAutoBattler()
-    
-    # Test getTotal function indirectly by calling a public function that uses it
-    def test_get_total(id):
-        # Call the internal getTotal function through the public sortWorms
-        total = wyrm_sorting_contract.getTotal(id)
-        expected_total = (100 + id) + (200 + id) + (300 + id) + (400 + id)
-        assert total == expected_total, f"Total {total} does not match expected {expected_total}"
-    
-    # Test for a few ids
+    # Test getTotal function for a few ids
     for wyrm_id in range(1, 4):
-        test_get_total(wyrm_id)
+        total = wyrm_sorting_contract.getTotal(mock_wyrm_auto_battler.address, wyrm_id, sender=owner)
+        expected_total = (100 + wyrm_id) + (200 + wyrm_id) + (300 + wyrm_id) + (400 + wyrm_id)
+        assert total == expected_total, f"Total {total} does not match expected {expected_total}"
     
     print("Test passed, getTotal method works correctly.")
 
 # Call the test function
-test_sort_worms(accounts)
+test_get_total_stats(accounts)

--- a/tests/wyrm-leaderboard-tester.py
+++ b/tests/wyrm-leaderboard-tester.py
@@ -16,5 +16,34 @@ def test_get_total_stats(accounts):
     
     print("Test passed, getTotal method works correctly.")
 
-# Call the test function
+def test_sort_accounts(accounts):
+    # Deploy the WyrmSorting contract
+    owner = accounts[0]
+    wyrm_sorting_contract = project.WyrmSorting.deploy(sender=owner)
+
+    # Deploy the MockWyrmAutoBattler contract
+    mock_wyrm_auto_battler = project.MockWyrmAutoBattler.deploy(sender=owner)
+
+    # Set up accounts and corresponding IDs
+    test_accounts = accounts[:10]
+    test_ids = [i for i in range(1, 11)]
+
+    # Set total stats for each ID in the MockWyrmAutoBattler contract
+    for i, acc_id in enumerate(test_ids):
+        mock_wyrm_auto_battler.setTotalStats(acc_id, 10 - i, sender=owner)  # Decreasing totals for simplicity
+
+    # Call quicksort_accounts in the Vyper contract
+    sorted_accounts = wyrm_sorting_contract.quicksort_accounts(mock_wyrm_auto_battler.address, test_accounts, test_ids, sender=owner)
+
+    # Retrieve the sorted totals for validation
+    sorted_totals = [mock_wyrm_auto_battler.getTotalStats(test_ids[i], sender=owner) for i in range(10)]
+    expected_sorted_totals = sorted(sorted_totals)
+
+    # Verify the accounts are sorted correctly by their totals
+    assert sorted_totals == expected_sorted_totals, f"Sorted totals {sorted_totals} do not match expected {expected_sorted_totals}"
+
+    print("Test passed, quicksort_accounts method works correctly.")
+
+# Call the test functions
 test_get_total_stats(accounts)
+test_sort_accounts(accounts)


### PR DESCRIPTION
Adds total stats from WyrmAutoBattler together to create a comparable value between wyrms. Compares and sorts the accounts based on this new value using quicksort. Will be used as the backend to the wyrm-leaderboard, which will eventually display a list of accounts sorted based on this value.